### PR TITLE
feat: Add re-click spell to cancel option

### DIFF
--- a/src/main/java/com/ameliaxt/DisableCancelConfig.java
+++ b/src/main/java/com/ameliaxt/DisableCancelConfig.java
@@ -61,4 +61,15 @@ public interface DisableCancelConfig extends Config
 	{
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "reclickSpellToCancel",
+		name = "Re-click spell to cancel",
+		description = "Allow re-clicking the currently selected spell to cancel the selection."
+	)
+
+	default boolean reclickSpellToCancel()
+	{
+		return true;
+	}
 }

--- a/src/main/java/com/ameliaxt/DisableCancelPlugin.java
+++ b/src/main/java/com/ameliaxt/DisableCancelPlugin.java
@@ -73,6 +73,10 @@ public class DisableCancelPlugin extends Plugin {
 	}
 
 	private boolean isReclickOnSelectedWidget(Widget selectedWidget) {
+		if (selectedWidget.isHidden()) {
+			return false;
+		}
+
 		final Rectangle bounds = selectedWidget.getBounds();
 		final Point mouse = client.getMouseCanvasPosition();
 

--- a/src/main/java/com/ameliaxt/DisableCancelPlugin.java
+++ b/src/main/java/com/ameliaxt/DisableCancelPlugin.java
@@ -14,6 +14,7 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
+import java.awt.Rectangle;
 import java.util.Arrays;
 
 import static com.ameliaxt.TargetableSpells.TARGETABLE_SPELL_MAP;
@@ -71,6 +72,17 @@ public class DisableCancelPlugin extends Plugin {
 		return false;
 	}
 
+	private boolean isReclickOnSelectedWidget(Widget selectedWidget) {
+		final Rectangle bounds = selectedWidget.getBounds();
+		final Point mouse = client.getMouseCanvasPosition();
+
+		if (bounds == null || mouse == null) {
+			return false;
+		}
+
+		return bounds.contains(mouse.getX(), mouse.getY());
+	}
+
 	private boolean disableForRightClickOption() {
 		final boolean cfgLeftClickOnly = config.leftClickOnly();
 
@@ -106,6 +118,10 @@ public class DisableCancelPlugin extends Plugin {
 			}
 
 			if (!isItem && disableCancelForSpell(selectedWidget)) {
+				if (config.reclickSpellToCancel() && isReclickOnSelectedWidget(selectedWidget)) {
+					return false;
+				}
+
 				return true;
 			}
 		}


### PR DESCRIPTION
Resolves #4

Adds a configurable setting (enabled by default) that allows re-clicking the currently selected spell in the spellbook to cancel the selection. Detected by matching the clicked menu entry's widget id against the selected spell widget on CANCEL actions.

I'd love to be added as a collaborator to help maintain this plugin :)